### PR TITLE
type error in response

### DIFF
--- a/os.go
+++ b/os.go
@@ -25,7 +25,7 @@ type ShellOs struct {
 	CPU     string   // x86_64
 	Purpose string   // unknown|desktop|server|mobile
 	Cmdline string   // cmdline for guest-linux
-	Flags   []string // byol_warning
+	Flags   struct{} // byol_warning
 }
 
 type ShellOsImage struct {


### PR DESCRIPTION
Hey noticed this error:

`2022/09/09 16:12:20 failed: json: cannot unmarshal object into Go struct field ShellOs.OS.Flags of type []string`

Would be caught by tests but this seems like a quicky tool thing. After playing around I traced it to to the change in `os.go`. No idea what the impact of this could be.

I'm testing image upload now but it's going to take a while to upload an 8G image from my localhost.

Edit: took the `tar.gz` raw file, so upload worked.

```
gomoddevgithub.comelebertusshells-climaster ./shells-cli-fork  os image upload -os $shlos -file fart.raw.tar.gz
2022/09/09 16:51:14 Uploading fart.raw.tar.gz ...
$shosi 20220909 fart.raw.tar.gz
gomoddevgithub.comelebertusshells-climaster ls -alh fart.raw.tar.gz
-rw-r--r--  1 eblack  staff   8.0M Sep  9 16:51 fart.raw.tar.gz
gomoddevgithub.comelebertusshells-climaster ./shells-cli-fork  os image ls -os $shlos 20220909 fart.raw.tar.gz
gomoddevgithub.comelebertusshells-climaster ./shells-cli-fork  os ls
$shlos pisswizardOs
```
